### PR TITLE
Add possibillity to customize port where IEDriverServer is listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Type: `Boolean`
 
 Default: `false`
 
+### port
+Port number where IEDriver will listen. Default is 5555.
+
+Type: `String`
+
 ----
 
 For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -12,6 +12,7 @@ class IEDriverLauncher {
         this.ieDriverArgs = {}
         this.logToStdout = false
         this.killInstances = false
+        this.port = null;
     }
 
     onPrepare (config) {
@@ -19,9 +20,10 @@ class IEDriverLauncher {
         this.ieDriverLogs = config.ieDriverLogs
         this.logToStdout = config.logToStdout
         this.killInstances = config.killInstances
+        this.port = (config.port == undefined || config.port == null) ? '5555' : config.port;
 
         return new Promise((resolve, reject) => {
-            this.process = childProcess.execFile(binPath, [], (err, stdout, stderr) => {
+            this.process = childProcess.execFile(binPath, ['--port=' + _this.port], (err, stdout, stderr) => {
                 if (err) {
                     console.log('Error in process: ' + err)
                     return reject(err)


### PR DESCRIPTION
I cam along an issue where the default IEDriverServer port was already blocked by another system application. So I needed to customize the port for IEDriverServer. 

With the proposed modifications the port property is used to pass it as '--port' argument to the executable.